### PR TITLE
Skip rails links which has data-method attribute

### DIFF
--- a/lib/medusa/page.rb
+++ b/lib/medusa/page.rb
@@ -60,6 +60,7 @@ module Medusa
       return @links if !doc
 
       doc.search("//a[@href]").each do |a|
+        next if a['data-method'] && a['data-method'] != 'get'
         u = a['href']
         next if u.nil? or u.empty?
         abs = to_absolute(u) rescue next

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -132,6 +132,16 @@ module Medusa
         page.links.should have(1).link
         page.links.first.to_s.should == SPEC_DOMAIN
       end
+
+      it 'should not return rails ujs links with data-method attribute' do
+        body = '<a data-method="delete" href="/delete_me">Something</a>' \
+               '<a data-method="patch" href="/patch_me">Something</a>' \
+               '<a href="/get_me">Something</a>'
+        page = @http.fetch_page(FakePage.new('', body: body).url)
+        page.links.should have(1).link
+        page.links[0].should be_a(URI)
+        page.links[0].to_s == 'http://www.example.com/get_me'
+      end
     end
 
     it "should detect, store and expose the base url for the page head" do


### PR DESCRIPTION
@brutuscat 

I have been trying to use Anemone (now Medusa :smile: ) to smoke test some of my projects. I ran into a scenario where it reports `404` where it finds `Rails` delete or update links with `data-method` attribute.
```html
<a class="btn btn-danger pull-right" data-confirm="Are you sure?" rel="nofollow" data-method="delete" href="/designs/1">Delete</a>
```
I thought it's a good idea to skip these links in general.